### PR TITLE
fix(index): replace 'index' by 'Inicio' on main page

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -71,7 +71,7 @@ def render_pages(template, md):
 def render_index(template):
     # Special case for the index
     _header = {
-        "@title": "index",
+        "@title": "Inicio",
         "@url": "index.html",
     }
     conf = {


### PR DESCRIPTION
En la página principal quedaba 'index' como título. Lo ajusté cambiando directamente el script `generate.py` y ahora muestra 'Inicio'. 

![image](https://github.com/user-attachments/assets/e35e2773-d286-4cc4-95c2-e64014f358e8)

Una alternativa es no tocar el script y meter un if else para evaluar si header['@title'] es igual a "index" (pero me parece un enchastre).

